### PR TITLE
Prefer HTTPS for loading remote fonts

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -2,7 +2,7 @@
 ---
 @charset 'UTF-8';
 @import url('font-awesome.min.css');
-@import url('http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,400,400italic,600,600italic,700,700italic');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,400,400italic,600,600italic,700,700italic');
 
 @import 'vars';
 @import 'mixins';


### PR DESCRIPTION
When serving the site over HTTPS, some browsers may not load assets not also served via HTTPS, e.g. these fonts :)